### PR TITLE
Update react highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "next": "^4.2.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-highlight": "^0.10.0",
+    "react-highlight": "^0.12.0",
     "webpack-bundle-analyzer": "^2.8.3"
   }
 }


### PR DESCRIPTION
When following along the tutorial on nextjs.org here:

https://nextjs.org/learn/excel/lazy-loading-components/setup

I kept running into the error message below when navigating to http://localhost:3000/p/hello-nextjs

Upgrading react highlight appears to fix the issue.

![image](https://user-images.githubusercontent.com/1438493/41195708-5d18678e-6bf8-11e8-8eed-5005fc5306dc.png)
