### PR TITLE
Upgrade react-highlight version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "next": "^4.2.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-highlight": "^0.10.0",
+    "react-highlight": "^0.12.0",
     "webpack-bundle-analyzer": "^2.8.3"
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/zeit/next-site/issues/39


### Description
After following all the steps and running the app, visiting http://localhost:3000/p/hello-nextjs will output the error Cannot read property 'querySelectorAll' of null with a stack trace.

### To Reproduce
Steps to reproduce the behavior, please provide code snippets or a repository:

* Go to https://nextjs.org/learn/excel/lazy-loading-components/setup
* Follow the steps
* Visit http://localhost:3000/p/hello-nextjs
* See error
