### PR TITLE
Update React highlight version to 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "next": "^6.1.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-highlight": "^0.10.0",
+    "react-highlight": "^0.12.0",
     "webpack-bundle-analyzer": "^2.8.3"
   }
 }


### PR DESCRIPTION
React highlight fail after "next" update to v 6.1.1