### PR TITLE
Fixes #45 bundle-analyzer port conflict

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,8 +5,7 @@ module.exports = {
   webpack: function (config) {
     if (ANALYZE) {
       config.plugins.push(new BundleAnalyzerPlugin({
-        analyzerMode: 'server',
-        analyzerPort: 8888,
+        analyzerMode: 'static',
         openAnalyzer: true
       }))
     }


### PR DESCRIPTION
Switching to static rendering for `webpack-bundle-analyzer`